### PR TITLE
Fix: Add fs.rmSync polyfill

### DIFF
--- a/packages/vue-cli-plugin-image-modernizer/src/index.ts
+++ b/packages/vue-cli-plugin-image-modernizer/src/index.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import './rmSync-polyfill.ts'
 import mime from "mime";
 import path from "path";
 import { Compiler, Plugin, loader } from "webpack";

--- a/packages/vue-cli-plugin-image-modernizer/src/rmSync-polyfill.ts
+++ b/packages/vue-cli-plugin-image-modernizer/src/rmSync-polyfill.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+
 if (!fs.rmSync) {
   const rimraf = require("rimraf");
   fs.rmSync = (path: fs.PathLike) => {

--- a/packages/vue-cli-plugin-image-modernizer/src/rmSync-polyfill.ts
+++ b/packages/vue-cli-plugin-image-modernizer/src/rmSync-polyfill.ts
@@ -1,0 +1,7 @@
+import fs from "fs";
+if (!fs.rmSync) {
+  const rimraf = require("rimraf");
+  fs.rmSync = (path: fs.PathLike) => {
+    return rimraf.sync(path);
+  };
+}


### PR DESCRIPTION
Add polyfill for `rmSync` to add node support >14v
Took from [here](https://github.com/Jarred-Sumner/git-peek/commit/bbbd338b86359da3d20ec417bbf3d0e0abab29b8#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R28-R36)