### PR TITLE
fix(vue-cli-plugin-image-modernizer):  Error Cannot find module "./rmSync-polyfill.ts

### DIFF
--- a/packages/vue-cli-plugin-image-modernizer/src/index.ts
+++ b/packages/vue-cli-plugin-image-modernizer/src/index.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import './rmSync-polyfill.ts'
+import './rmSync-polyfill'
 import mime from "mime";
 import path from "path";
 import { Compiler, Plugin, loader } from "webpack";


### PR DESCRIPTION
Due to the fact that the file extension was specified [here](https://github.com/Calvin-LL/vue-image-modernizer/blob/main/packages/vue-cli-plugin-image-modernizer/src/index.ts#L2)  when importing rmSync-polyfill.ts

Extension did not change to js after build
So there is a Error `Error Cannot find module "./rmSync-polyfill.ts`

_Example of dist/index.js_

![image](https://user-images.githubusercontent.com/42942944/124278203-419e0200-db46-11eb-9e58-769ff87dfe2b.png)

So I removed extenstion when importing file
